### PR TITLE
Handle Go versions with pre-release details

### DIFF
--- a/get_e2e_test.go
+++ b/get_e2e_test.go
@@ -702,7 +702,7 @@ func TestGet(t *testing.T) {
 						},
 						expectRows: []row{
 							// TODO(bwplotka) This will be painful to maintain, but well... improve it
-							{name: "thanos", binName: "thanos-v0.18.0", pkgVersion: "github.com/thanos-io/thanos/cmd/thanos@v0.18.0"},
+							{name: "thanos", binName: "thanos-v0.19.0", pkgVersion: "github.com/thanos-io/thanos/cmd/thanos@v0.19.0"},
 						},
 						expectBinaries: []string{
 							"buildable",
@@ -712,7 +712,7 @@ func TestGet(t *testing.T) {
 							"f2-v1.0.0", "f2-v1.1.0", "f2-v1.2.0", "f2-v1.3.0", "f2-v1.4.0", "f2-v1.5.0", "f3-v1.1.0", "f3-v1.3.0", "f3-v1.4.0",
 							"faillint-v1.0.0", "faillint-v1.1.0", "faillint-v1.3.0", "faillint-v1.4.0", "faillint-v1.5.0",
 							"go-bindata-v3.1.1+incompatible",
-							"thanos-v0.13.1-0.20210108102609-f85e4003ba51", "thanos-v0.18.0",
+							"thanos-v0.13.1-0.20210108102609-f85e4003ba51", "thanos-v0.19.0",
 							"wr_buildable-v0.0.0-20210109165512-ccbd4039b94a", "wr_buildable-v0.0.0-20210110214650-ab990d1be30b",
 						},
 					},
@@ -727,7 +727,7 @@ func TestGet(t *testing.T) {
 						},
 						expectRows: []row{
 							// TODO(bwplotka) This will be painful to maintain, but well... improve it
-							{name: "thanos", binName: "thanos-v0.18.0", pkgVersion: "github.com/thanos-io/thanos/cmd/thanos@v0.18.0"},
+							{name: "thanos", binName: "thanos-v0.19.0", pkgVersion: "github.com/thanos-io/thanos/cmd/thanos@v0.19.0"},
 						},
 						expectSameBinariesAsBefore: true,
 					},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -20,6 +20,7 @@ func TestParseAndIsSupportedVersion(t *testing.T) {
 		{output: "go version go1.1 linux/amd64", errs: errors.New("found unsupported go version: 1.1.0; requires go 1.14.x or higher")},
 		{output: "go version go1 linux/amd64", errs: errors.New("found unsupported go version: 1.0.0; requires go 1.14.x or higher")},
 		{output: "go version go1.1.2 linux/amd64", errs: errors.New("found unsupported go version: 1.1.2; requires go 1.14.x or higher")},
+		{output: "go version go1.12rc1 linux/amd64", errs: errors.New("found unsupported go version: 1.12.0; requires go 1.14.x or higher")},
 		{output: "go version go1.12 linux/amd64", errs: errors.New("found unsupported go version: 1.12.0; requires go 1.14.x or higher")},
 		{output: "go version go1.13 linux/amd64", errs: errors.New("found unsupported go version: 1.13.0; requires go 1.14.x or higher")},
 		{output: "go version go1.13.2 linux/amd64", errs: errors.New("found unsupported go version: 1.13.2; requires go 1.14.x or higher")},
@@ -27,6 +28,8 @@ func TestParseAndIsSupportedVersion(t *testing.T) {
 		{output: "go version go1.14.2 linux/amd64"},
 		{output: "go version go1.15 linux/amd64"},
 		{output: "go version go1.15.44 linux/amd64"},
+		{output: "go version go1.16beta1 linux/amd64"},
+		{output: "go version go1.16rc1 linux/amd64"},
 		{output: "go version go2 linux/amd64"},
 		{output: "go version go2.1 linux/amd64"},
 	} {


### PR DESCRIPTION
This pull request updates the implementation of parseGoVersion so it can capture the Go version number when dealing with pre-releases like go1.16rc1 or go1.16beta1. Without this fix, bingo fails with the following error:

    $ bingo list
    Error: list command failed: Invalid Semantic Version

See https://github.com/bwplotka/bingo/issues/70 for more.