### PR TITLE
Add support for short module names

### DIFF
--- a/get.go
+++ b/get.go
@@ -470,7 +470,7 @@ func resolveInGoModCache(logger *log.Logger, verbose bool, update runner.GetUpda
 
 	// Since we don't know which part of full path is package, which part is module.
 	// Start from longest and go until we find one.
-	for ; len(strings.Split(lookupModulePath, "/")) > 2; func() {
+	for ; len(strings.Split(lookupModulePath, "/")) >= 2; func() {
 		lookupModulePath = filepath.Dir(lookupModulePath)
 		modulePath = filepath.Dir(modulePath)
 	}() {

--- a/get_e2e_test.go
+++ b/get_e2e_test.go
@@ -99,6 +99,15 @@ func TestGet(t *testing.T) {
 						expectBinaries: []string{"faillint-v1.4.0"},
 					},
 					{
+						name: "get get istio.io/tools/cmd/cue-gen@355a0b7a6ba743d14e3a43a3069287086207f35c (short module base path)",
+						do: func(t *testing.T) {
+							fmt.Println(g.ExecOutput(t, p.root, bingoPath, "get", "istio.io/tools/cmd/cue-gen@355a0b7a6ba743d14e3a43a3069287086207f35c"))
+							testutil.Equals(t, g.ExecOutput(t, p.root, bingoPath, "list", "cue-gen"), g.ExecOutput(t, p.root, bingoPath, "list"))
+						},
+						expectRows:     []row{{name: "cue-gen", binName: "cue-gen-v0.0.0-20210909062344-355a0b7a6ba7", pkgVersion: "istio.io/tools/cmd/cue-gen@v0.0.0-20210909062344-355a0b7a6ba7"}},
+						expectBinaries: []string{"cue-gen-v0.0.0-20210909062344-355a0b7a6ba7"},
+					},
+					{
 						name: "get github.com/bwplotka/bingo/testdata/module/buildable@2e6391144e85de14181f8e47b77d64b94a7ca3a8",
 						do: func(t *testing.T) {
 							fmt.Println(g.ExecOutput(t, p.root, bingoPath, "get", "github.com/bwplotka/bingo/testdata/module/buildable@2e6391144e85de14181f8e47b77d64b94a7ca3a8"))


### PR DESCRIPTION
The current code assumes module names have 3 or more path segments (typically `github.com/org/module`), but there are cases where custom module names may not follow that convention and be just `domain/module`. This is a small fix to support those modules as well.