### PR TITLE
add -json flag for json output

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		" maintained. If does not exists, bingo list will fail.")
 	// Go flags is so broken, need to add shadow -v flag to make those work in both before and after `list` command.
 	listVerbose := listFlags.Bool("v", false, "Print more'")
+	listJSON := listFlags.Bool("json", false, "output to json")
 
 	flags.Usage = func() {
 		getFlagsHelp := &strings.Builder{}
@@ -186,6 +187,9 @@ func main() {
 			}
 
 			bingo.SortRenderables(pkgs)
+			if *listJSON {
+				return pkgs.PrintJSON(target, os.Stdout)
+			}
 			return pkgs.PrintTab(target, os.Stdout)
 		}
 	case "version":


### PR DESCRIPTION
This is a great tool for helping manage developer environments. One thing that would increase the usability for our team is being able to check the binaries from `list` and ensure that they are installed from a script.

Rather than having to parse the tab output with bash, I think a `json` output makes this much easier. My proposal is to add a `-json` flag for output.

For example, this is a small script that checks if we have a binary installed:
```
for b in $(./bingo list -json | jq -r '.[] | .binary_name'); do
        if ! command -v $b;
                then echo "$b not found";
        else
                echo "$b found"
        fi
done
```

Hopefully not too big of a PR! Let me know if there's anything else needed for this.