### PR TITLE
Relax parsing of go version

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -32,20 +32,16 @@ type Runner struct {
 	logger *log.Logger
 }
 
-var versionRegexp = regexp.MustCompile(`go?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?`)
+var versionRegexp = regexp.MustCompile(`^go version.* go((?:[0-9]+)(?:\.[0-9]+)?(?:\.[0-9]+)?)`)
 
 // parseGoVersion ignores pre-release identifiers immediately following the
 // patch version since we don't expect goVersionOutput to be SemVer-compliant.
 func parseGoVersion(goVersionOutput string) (*semver.Version, error) {
-	el := strings.Fields(strings.TrimRight(goVersionOutput, "\n"))
-	if len(el) < 2 {
+	goVersion := versionRegexp.FindStringSubmatch(goVersionOutput)
+	if goVersion == nil {
 		return nil, errors.Newf("unexpected go version output; expected 'go version go<semver> ...; found %v", strings.TrimRight(goVersionOutput, "\n"))
 	}
-	goVersion := versionRegexp.FindString(el[2])
-	if goVersion == "" {
-		return nil, errors.New("unexpected go version format")
-	}
-	return semver.NewVersion(strings.TrimPrefix(goVersion, "go"))
+	return semver.NewVersion(goVersion[1])
 }
 
 func isSupportedVersion(v *semver.Version) error {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -32,6 +32,7 @@ func TestParseAndIsSupportedVersion(t *testing.T) {
 		{output: "go version go1.16rc1 linux/amd64"},
 		{output: "go version go2 linux/amd64"},
 		{output: "go version go2.1 linux/amd64"},
+		{output: "go version devel go1.21-02d8ebda83 Mon Feb 6 22:13:07 2023 +0000 linux/amd64"},
 	} {
 		t.Run(tcase.output, func(t *testing.T) {
 			errs := merrors.New()


### PR DESCRIPTION
Development versions of Go have an additional token before the version:

```
go version devel go1.21-02d8ebda83 Mon Feb 6 22:13:07 2023 +0000 linux/amd64
```

Use the regular expression on the whole output of go version instead of just on the third token.

Fixes https://github.com/bwplotka/bingo/issues/131