### PR TITLE
Adding a --timeout flag as 'go get' or building the code may take longer than 5 minutes

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -28,6 +28,7 @@ func NewBingoGetCommand(logger *log.Logger) *cobra.Command {
 		name     string
 		insecure bool
 		link     bool
+		timeOut  uint
 	)
 
 	cmd := &cobra.Command{
@@ -89,8 +90,9 @@ func NewBingoGetCommand(logger *log.Logger) *cobra.Command {
 				relModDir: moddir,
 				name:      name,
 				rename:    rename,
-				verbose:   verbose,
 				link:      link,
+				timeOut:   timeOut,
+				verbose:   verbose,
 			}
 			var target string
 			if len(args) > 0 {
@@ -121,6 +123,8 @@ func NewBingoGetCommand(logger *log.Logger) *cobra.Command {
 	flags.BoolVar(&insecure, "insecure", insecure, `Use -insecure flag when using 'go get'`)
 	flags.BoolVarP(&link, "link", "l", link, "If enabled, bingo will also create soft link called <tool> that links to the current <tool>-<version> binary.\n"+
 		"Use Variables.mk and variables.env if you want to be sure that what you are invoking is what is pinned.")
+	flags.UintVarP(&timeOut, "timeout", "t", 5, "The maximum time (in minutes) to wait for each go command before killing it.\n"+
+		"Set this flag to 0 to indefinitely wait on them.")
 	return cmd
 }
 

--- a/get.go
+++ b/get.go
@@ -88,6 +88,7 @@ type getConfig struct {
 	rename    string
 	link      bool
 
+	timeOut uint
 	verbose bool
 }
 
@@ -138,7 +139,12 @@ func existingModFiles(modDir string, targetName string) (existingModFiles []stri
 // get performs bingo get: it's like go get, but package aware, without go source files and on dedicated mod file.
 // rawTarget is name or target package path, optionally with module version or array versions.
 func get(ctx context.Context, logger *log.Logger, c getConfig, rawTarget string) (err error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute) // TODO(bwplotka): Put as param?
+	var cancel context.CancelFunc = func() {}
+
+	if c.timeOut > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.timeOut)*time.Minute)
+	}
+
 	defer cancel()
 
 	// Cleanup all bingo modules' tmp files for fresh start.


### PR DESCRIPTION
With the hot weather, I am experiencing some thermal throttling on my computer and `bingo` will fail as some commands it runs are taking longer than 5 minutes.