### PR TITLE
.gitignore: add .envrc to the ignore list

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-export GOBIN="/home/bwplotka/Repos/bingo/.bin"
-export GOPATH="/home/bwplotka/Repos/sharedgopath"
-export GOPROXY="https://proxy.golang.org"
-export PATH="$GOBIN:$GOROOT/bin:$PATH"
-

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor/
 
 .idea/
 examples/tmp-demo
+
+# Ignore envrc
+.envrc


### PR DESCRIPTION
The .envrc file includes environment-specific paths and settings that
should not be tracked in source control as they can vary between
developers' environments.

Removed the .envrc file from version control and updated .gitignore to
reflect this change, improving developer experience by avoiding
conflicts with personal configurations.
