### PR TITLE
Fix: workaround for using tools with no go directive in their go.mod

### DIFF
--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -124,6 +124,12 @@ func (mf *File) AddComment(comment string) error {
 
 	return mf.flush()
 }
+
+// GoVersion returns a semver string containing the value of of the go directive.
+// For example, it will return "1.2.3" if the go.mod file contains the line "go 1.2.3".
+// If no go directive is found, it returns "1.0" because:
+// 1. "1.0" is a valid semver string, so it's always safe to parse this value using semver.MustParse().
+// 2. The semantics of the absence of a go directive in a go.mod file means all versions of Go should be able to compile it.
 func (mf *File) GoVersion() string {
 	if mf.m.Go == nil {
 		return "1.0"

--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -126,7 +126,7 @@ func (mf *File) AddComment(comment string) error {
 }
 func (mf *File) GoVersion() string {
 	if mf.m.Go == nil {
-		return ""
+		return "1.0"
 	}
 	return mf.m.Go.Version
 }

--- a/pkg/mod/mod_test.go
+++ b/pkg/mod/mod_test.go
@@ -43,7 +43,7 @@ func TestFile(t *testing.T) {
 		testutil.Equals(t, "", p)
 		testutil.Equals(t, "", comment)
 		testutil.Equals(t, []string(nil), mf.Comments())
-		testutil.Equals(t, "", mf.GoVersion())
+		testutil.Equals(t, "1.0", mf.GoVersion())
 		testutil.Equals(t, 0, len(mf.RequireDirectives()))
 		testutil.Equals(t, 0, len(mf.ReplaceDirectives()))
 		testutil.Equals(t, 0, len(mf.ExcludeDirectives()))


### PR DESCRIPTION
According to https://go.dev/ref/mod#go-mod-file-go, prior to Go 1.21, the go directive was option.
This seems to not be supported in bingo. This commit only changes the fallback value used when a go.mod file does not contain the version. This semantically means that any go version should be able to compile this.

I encountered the issue while trying to use bingo to install github.com/betacraft/easytags Their go.mod is completely empty, which causes a panic on

if semver.MustParse(targetModParsed.GoVersion()).GreaterThan(runnable.GoVersion()) {

`get.go:723`

---
Steps to recreate: 
```sh
bingo get github.com/betacraft/easytags@latest
```
---

Thanks for the great tool!